### PR TITLE
(Ios) add custom message & allow message to automatically close on scan

### DIFF
--- a/NfcManager.js
+++ b/NfcManager.js
@@ -23,7 +23,7 @@ class NfcManager {
     this._subscription = null;
   }
 
-  start({onSessionClosedIOS} = {}) {
+  start({ onSessionClosedIOS } = {}) {
     return new Promise((resolve, reject) => {
       NativeNfcManager.start(resolve);
     })
@@ -55,10 +55,10 @@ class NfcManager {
     })
   }
 
-  registerTagEvent(listener, alertMessage = '') {
+  registerTagEvent(listener, alertMessage = '', invalidateAfterFirstRead = false) {
     if (!this._subscription) {
       return new Promise((resolve, reject) => {
-        NativeNfcManager.registerTagEvent(alertMessage, () => {
+        NativeNfcManager.registerTagEvent(alertMessage, invalidateAfterFirstRead, () => {
           this._clientTagDiscoveryListener = listener;
           this._subscription = NfcManagerEmitter.addListener(Events.DiscoverTag, this._handleDiscoverTag);
           resolve();

--- a/NfcManager.js
+++ b/NfcManager.js
@@ -23,7 +23,7 @@ class NfcManager {
     this._subscription = null;
   }
 
-  start({onSessionClosedIOS}={}) {
+  start({onSessionClosedIOS} = {}) {
     return new Promise((resolve, reject) => {
       NativeNfcManager.start(resolve);
     })
@@ -55,10 +55,10 @@ class NfcManager {
     })
   }
 
-  registerTagEvent(listener) {
+  registerTagEvent(listener, alertMessage = '') {
     if (!this._subscription) {
       return new Promise((resolve, reject) => {
-        NativeNfcManager.registerTagEvent(() => {
+        NativeNfcManager.registerTagEvent(alertMessage, () => {
           this._clientTagDiscoveryListener = listener;
           this._subscription = NfcManagerEmitter.addListener(Events.DiscoverTag, this._handleDiscoverTag);
           resolve();
@@ -89,10 +89,10 @@ class NfcManager {
   }
 
   _handleSessionClosed = () => {
-      this._clientTagDiscoveryListener = null;
-      this._subscription.remove();
-      this._subscription = null;
-      this._clientSessionClosedListener && this._clientSessionClosedListener();
+    this._clientTagDiscoveryListener = null;
+    this._subscription.remove();
+    this._subscription = null;
+    this._clientSessionClosedListener && this._clientSessionClosedListener();
   }
 }
 

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ __Examples__
 ```js
 NfcManager.registerTagEvent(tag => {
     console.log('Tag Discovered', tag);
-})
+}, 'Hold your device over the tag', true)
 ```
 
 ### unregisterTagEvent()

--- a/README.md
+++ b/README.md
@@ -84,11 +84,13 @@ Direct the user to NFC setting.
 Get the NFC tag object which launches the app.
 Returned `Promise` resolved to the NFC tag object launching the app and resolved to null if the app isn't launched by NFC tag.
 
-### registerTagEvent(listener)
+### registerTagEvent(listener, alertMessage, invalidateAfterFirstRead)
 Start to listen to *ANY* NFC tags.
 
 __Arguments__
 - `listener` - `function` - the callback when discovering NFC tags
+- `alertMessage` - `string` - (iOS) the message to display on iOS when the NFCScanning pops up
+- `invalidateAfterFirstRead` - `boolean` - (iOS) when set to true this will not have you prompt to click done after NFC Scan.
 
 __Examples__
 ```js

--- a/android/src/main/java/community/revteltech/nfc/NfcManager.java
+++ b/android/src/main/java/community/revteltech/nfc/NfcManager.java
@@ -102,7 +102,7 @@ class NfcManager extends ReactContextBaseJavaModule implements ActivityEventList
 	}
 
 	@ReactMethod
-    private void registerTagEvent(Callback callback) {
+    private void registerTagEvent(String alertMessage, Boolean invalidateAfterFirstRead, Callback callback) {
         Log.d(LOG_TAG, "registerTag");
 		isForegroundEnabled = true;
 
@@ -147,14 +147,14 @@ class NfcManager extends ReactContextBaseJavaModule implements ActivityEventList
 			enableDisableForegroundDispatch(true);
 		}
     }
-    
+
     @Override
     public void onHostPause() {
         Log.d(LOG_TAG, "onPause");
 		isResumed = false;
 		enableDisableForegroundDispatch(false);
     }
-    
+
     @Override
     public void onHostDestroy() {
         Log.d(LOG_TAG, "onDestroy");

--- a/ios/NfcManager.m
+++ b/ios/NfcManager.m
@@ -95,7 +95,7 @@ RCT_EXPORT_METHOD(start: (nonnull RCTResponseSenderBlock)callback)
     }
 }
 
-RCT_EXPORT_METHOD(registerTagEvent: (NSString *)alertMessage invalidateAfterFirstRead:(bool)invalidateAfterFirstRead callback:(nonnull RCTResponseSenderBlock)callback)
+RCT_EXPORT_METHOD(registerTagEvent: (NSString *)alertMessage invalidateAfterFirstRead:(BOOL)invalidateAfterFirstRead callback:(nonnull RCTResponseSenderBlock)callback)
 {
     if (@available(iOS 11.0, *)) {
         if (session == nil) {

--- a/ios/NfcManager.m
+++ b/ios/NfcManager.m
@@ -95,11 +95,12 @@ RCT_EXPORT_METHOD(start: (nonnull RCTResponseSenderBlock)callback)
     }
 }
 
-RCT_EXPORT_METHOD(registerTagEvent: (nonnull RCTResponseSenderBlock)callback)
+RCT_EXPORT_METHOD(registerTagEvent: (NSString *)alertMessage callback:(nonnull RCTResponseSenderBlock)callback)
 {
     if (@available(iOS 11.0, *)) {
         if (session == nil) {
             session = [[NFCNDEFReaderSession alloc] initWithDelegate:self queue:dispatch_get_main_queue() invalidateAfterFirstRead:false];
+            session.alertMessage = alertMessage;
             [session beginSession];
         }
         callback(@[]);

--- a/ios/NfcManager.m
+++ b/ios/NfcManager.m
@@ -95,11 +95,11 @@ RCT_EXPORT_METHOD(start: (nonnull RCTResponseSenderBlock)callback)
     }
 }
 
-RCT_EXPORT_METHOD(registerTagEvent: (NSString *)alertMessage callback:(nonnull RCTResponseSenderBlock)callback)
+RCT_EXPORT_METHOD(registerTagEvent: (NSString *)alertMessage invalidateAfterFirstRead:(bool)invalidateAfterFirstRead callback:(nonnull RCTResponseSenderBlock)callback)
 {
     if (@available(iOS 11.0, *)) {
         if (session == nil) {
-            session = [[NFCNDEFReaderSession alloc] initWithDelegate:self queue:dispatch_get_main_queue() invalidateAfterFirstRead:false];
+            session = [[NFCNDEFReaderSession alloc] initWithDelegate:self queue:dispatch_get_main_queue() invalidateAfterFirstRead:invalidateAfterFirstRead];
             session.alertMessage = alertMessage;
             [session beginSession];
         }


### PR DESCRIPTION
This pull request adds 2 features. 
The first is the ability to add a custom message such as "Hold iPhone near the fire" shown below.
![image](https://user-images.githubusercontent.com/8260678/32951443-e89362cc-cb77-11e7-9aaf-3031bc1e7546.png)
The second is the ability to have the popup automatically close when a tag is scanned & not have to click the "done" button to close the popup. 
