### PR TITLE
Quote style and add header search path

### DIFF
--- a/ios/NfcManager.h
+++ b/ios/NfcManager.h
@@ -1,10 +1,10 @@
 #if __has_include(<React/RCTBridgeModule.h>)
 #import <React/RCTBridgeModule.h>
 #import <React/RCTEventEmitter.h>
-#elif __has_include(“React/RCTBridgeModule.h”)
-#import “React/RCTBridgeModule.h”
+#elif __has_include("React/RCTBridgeModule.h")
+#import "React/RCTBridgeModule.h"
 #else
-#import “RCTBridgeModule.h”
+#import "RCTBridgeModule.h"
 #import <React/RCTEventEmitter.h>
 #endif
 #import <CoreNFC/CoreNFC.h>

--- a/ios/NfcManager.xcodeproj/project.pbxproj
+++ b/ios/NfcManager.xcodeproj/project.pbxproj
@@ -152,6 +152,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
+				HEADER_SEARCH_PATHS = "$(SRCROOT)/../../../ios/Pods/Headers/Public/**";
 				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
@@ -186,6 +187,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
+				HEADER_SEARCH_PATHS = "$(SRCROOT)/../../../ios/Pods/Headers/Public/**";
 				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
@@ -197,7 +199,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				HEADER_SEARCH_PATHS = (
-				"$(inherited)",
+					"$(inherited)",
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
 					"$(SRCROOT)/../../../React/**",
 					"$(SRCROOT)/../../react-native/React/**",

--- a/ios/NfcManager.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/ios/NfcManager.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/ios/NfcManager.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/ios/NfcManager.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>


### PR DESCRIPTION
Thanks for your job with this library.

## Quotes

I have some errors with [import quote style](https://github.com/whitedogg13/react-native-nfc-manager/compare/master...ieschalier:master#diff-acd4310b9c89341462cfcd4a502d4c88L4) in IOS Project : 

![screen shot 2018-04-12 at 11 31 41](https://user-images.githubusercontent.com/2832910/38795397-64e3915c-4158-11e8-9540-ab0fd045e977.png)

So i make quick update to fix that.

## Header search paths

I also add [header search path](https://github.com/whitedogg13/react-native-nfc-manager/compare/master...ieschalier:master#diff-0f42f84cd09e18166a2fa8bd74d449c2R155). So now react-native-nfc-manager work out of the box with expokit projects.
