### PR TITLE
added missing definition for parseText

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -73,6 +73,7 @@ declare module 'react-native-nfc-manager' {
 	const nfcManager: NfcManager;
 	export namespace NdefParser {
 		function parseUri(ndef: NdefRecord): ParseUriResult;
+		function parseText(ndef: NdefRecord): string | null;
 	}
 }
 


### PR DESCRIPTION
Hi there
I added a missing definition for the parseText function.

Thanks for creating react-native-nfc-manager!