### PR TITLE
added basic mifareclassic support

### DIFF
--- a/NfcManager.js
+++ b/NfcManager.js
@@ -19,6 +19,7 @@ const Events = {
 const NfcTech = {
   Ndef: 'Ndef',
   NfcA: 'NfcA',
+  MifareClassic: 'MifareClassic',
 }
 
 const LOG = 'NfcManagerJs';
@@ -342,6 +343,58 @@ class NfcManager {
 
     return new Promise((resolve, reject) => {
       NativeNfcManager.makeReadOnly((err, result) => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve(result);
+        }
+      })
+    })
+  }
+
+
+  // -------------------------------------
+  // NfcTech.MifareClassic API
+  // -------------------------------------
+  mifareClassicAuthenticateA(sector, key, callback) {
+    if (Platform.OS === 'ios') {
+      return Promise.reject('not implemented');
+    }
+
+    return new Promise((resolve, reject) => {
+      NativeNfcManager.mifareClassicAuthenticateA(sector, key, (err, result) => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve(result);
+        }
+      })
+    })
+  }
+
+  mifareClassicAuthenticateB(sector, key, callback) {
+    if (Platform.OS === 'ios') {
+      return Promise.reject('not implemented');
+    }
+
+    return new Promise((resolve, reject) => {
+      NativeNfcManager.mifareClassicAuthenticateB(sector, key, (err, result) => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve(result);
+        }
+      })
+    })
+  }
+
+  getMifareClassicMessage(sector, callback) {
+    if (Platform.OS === 'ios') {
+      return Promise.reject('not implemented');
+    }
+
+    return new Promise((resolve, reject) => {
+      NativeNfcManager.getMifareClassicMessage(sector, (err, result) => {
         if (err) {
           reject(err);
         } else {

--- a/android/src/main/java/community/revteltech/nfc/TagTechnologyRequest.java
+++ b/android/src/main/java/community/revteltech/nfc/TagTechnologyRequest.java
@@ -6,6 +6,7 @@ import android.nfc.TagLostException;
 import android.nfc.tech.TagTechnology;
 import android.nfc.tech.Ndef;
 import android.nfc.tech.NfcA;
+import android.nfc.tech.MifareClassic;
 import android.nfc.tech.IsoDep;
 import android.util.Log;
 import com.facebook.react.bridge.*;
@@ -47,6 +48,8 @@ class TagTechnologyRequest {
             mTech = NfcA.get(tag);
         } else if (mTechType.equals("IsoDep")) {
             mTech = IsoDep.get(tag);
+        } else if (mTechType.equals("MifareClassic")) {
+            mTech = MifareClassic.get(tag);
         }
 
         if (mTech == null) {


### PR DESCRIPTION
Added basic support for MifareClassic cards. Any feedback / suggestions welcome to get this PR merged upstream.

Usage sample:
```
      NfcManager.requestTechnology(NfcTech.MifareClassic)
        .then(() => {
          NfcManager.mifareClassicAuthenticateA(2, String.fromCharCode(0xff, 0xff, 0xff, 0xff, 0xff, 0xff)).then(() => {
              NfcManager.getMifareClassicMessage(2)
                .then(data => {
                  console.log('Received MifareClassic data', data);
                  return;
                })
                .catch(err => {
                  console.log('Failed to read data: ', err);
                });
            })
            .catch(err => {
              console.log('Failed to authenticate: ', err);
            });
        })
        .catch(err => {
          console.log('Failed to tech request: ', err);
        });
```