### PR TITLE
Fix a bugfix that sometimes occurs when the tag is a null object

### DIFF
--- a/android/src/main/java/community/revteltech/nfc/TagTechnologyRequest.java
+++ b/android/src/main/java/community/revteltech/nfc/TagTechnologyRequest.java
@@ -40,6 +40,11 @@ class TagTechnologyRequest {
     }
 
     boolean connect(Tag tag) {
+        if (tag == null) {
+            Log.d(LOG_TAG, "received null tag at connect()");
+            return false;
+        }
+
         mTech = null;
         mTag = tag;
         if (mTechType.equals("Ndef")) {


### PR DESCRIPTION
From Firebase:
--------------

Fatal Exception: java.lang.NullPointerException
Attempt to invoke virtual method 'boolean android.nfc.Tag.hasTech(int)' on a null object reference

android.nfc.tech.MifareClassic.get (MifareClassic.java:136)
community.revteltech.nfc.TagTechnologyRequest.connect (TagTechnologyRequest.java:52) <---
community.revteltech.nfc.NfcManager.parseNfcIntent (NfcManager.java:687)
community.revteltech.nfc.NfcManager.onNewIntent (NfcManager.java:657)
com.facebook.react.bridge.ReactContext.onNewIntent (ReactContext.java:197)
com.facebook.react.ReactInstanceManager.onNewIntent (ReactInstanceManager.java:455)
com.facebook.react.ReactActivityDelegate.onNewIntent (ReactActivityDelegate.java:179)
com.facebook.react.ReactActivity.onNewIntent (ReactActivity.java:107)
android.app.Instrumentation.callActivityOnNewIntent (Instrumentation.java:1315)