### PR TITLE
Feature/mifareclassic bytes instead of string

### DIFF
--- a/ByteParser.js
+++ b/ByteParser.js
@@ -1,0 +1,24 @@
+function byteToHexString(bytes) {
+  if (!Array.isArray(bytes) || !bytes.length) return '';
+
+  let result = '';
+  for (let i = 0; i < bytes.length; i++) {
+    result += `0${bytes[i].toString(16)}`.slice(-2);
+  }
+  return result;
+}
+
+function byteToString(bytes) {
+  if (!Array.isArray(bytes) || !bytes.length) return '';
+
+  let result = '';
+  for (let i = 0; i < bytes.length; i++) {
+    result += String.fromCharCode(bytes[i]);
+  }
+  return result;
+}
+
+export default {
+    byteToHexString,
+    byteToString,
+}

--- a/ByteParser.test.js
+++ b/ByteParser.test.js
@@ -1,0 +1,19 @@
+import ByteParser from './ByteParser';
+
+test('parse byteToHexString',  () => {
+  let payload = [104, 116, 116, 112, 115, 58, 47, 47, 103, 105, 116, 104, 117, 98, 46, 99, 111, 109, 47, 119, 104, 105, 116, 101, 100, 111, 103, 103, 49, 51, 47, 114, 101, 97, 99, 116, 45, 110, 97, 116, 105, 118, 101, 45, 110, 102, 99, 45, 109, 97, 110, 97, 103, 101, 114, 35, 114, 101, 97, 100, 109, 101];
+  expect(ByteParser.byteToHexString(payload)).toBe("68747470733a2f2f6769746875622e636f6d2f7768697465646f676731332f72656163742d6e61746976652d6e66632d6d616e6167657223726561646d65");
+});
+
+test('parse byteToHexString should return empty',  () => {
+  expect(ByteParser.byteToHexString({something: "wrong"})).toBe("");
+});
+
+test('parse byteToString',  () => {
+  let payload = [104, 116, 116, 112, 115, 58, 47, 47, 103, 105, 116, 104, 117, 98, 46, 99, 111, 109, 47, 119, 104, 105, 116, 101, 100, 111, 103, 103, 49, 51, 47, 114, 101, 97, 99, 116, 45, 110, 97, 116, 105, 118, 101, 45, 110, 102, 99, 45, 109, 97, 110, 97, 103, 101, 114, 35, 114, 101, 97, 100, 109, 101];
+  expect(ByteParser.byteToString(payload)).toBe("https://github.com/whitedogg13/react-native-nfc-manager#readme");
+});
+
+test('parse byteToString should return empty',  () => {
+  expect(ByteParser.byteToString({something: "wrong"})).toBe("");
+});

--- a/NfcManager.js
+++ b/NfcManager.js
@@ -4,6 +4,7 @@ import {
   NativeEventEmitter,
   Platform
 } from 'react-native'
+import ByteParser from './ByteParser'
 import NdefParser from './NdefParser'
 import Ndef from './ndef-lib'
 
@@ -361,6 +362,10 @@ class NfcManager {
       return Promise.reject('not implemented');
     }
 
+    if (!key || !Array.isArray(key) || key.length !== 6) {
+      return Promise.reject('key should be an Array[6] of integers (0 - 255)');
+    }
+
     return new Promise((resolve, reject) => {
       NativeNfcManager.mifareClassicAuthenticateA(sector, key, (err, result) => {
         if (err) {
@@ -375,6 +380,10 @@ class NfcManager {
   mifareClassicAuthenticateB(sector, key) {
     if (Platform.OS === 'ios') {
       return Promise.reject('not implemented');
+    }
+
+    if (!key || !Array.isArray(key) || key.length !== 6) {
+      return Promise.reject('key should be an Array[6] of integers (0 - 255)');
     }
 
     return new Promise((resolve, reject) => {
@@ -427,6 +436,7 @@ class NfcManager {
 export default new NfcManager();
 
 export {
+  ByteParser,
   NdefParser,
   NfcTech,
   Ndef,

--- a/example/AndroidMifareClassic.js
+++ b/example/AndroidMifareClassic.js
@@ -1,0 +1,220 @@
+import React, { Component } from 'react';
+import {
+  View,
+  Text,
+  Platform,
+  TouchableOpacity,
+  TextInput,
+  ScrollView,
+} from 'react-native';
+import NfcManager, { ByteParser, NfcTech } from 'react-native-nfc-manager';
+
+const KeyTypes = ['A', 'B'];
+
+class App extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      supported: false,
+      enabled: false,
+      isDetecting: false,
+      keyAorB: KeyTypes[1], // 'B'
+      keyToUse: 'FFFFFFFFFFFF',
+      sector: 0,
+      tag: {},
+      parsedText: null,
+    };
+  }
+
+  componentDidMount() {
+    NfcManager.isSupported().then(supported => {
+      this.setState({ supported });
+      if (supported) {
+        this._startNfc();
+      }
+    });
+  }
+
+  componentWillUnmount() {
+    if (this._stateChangedSubscription) {
+      this._stateChangedSubscription.remove();
+    }
+  }
+
+  render() {
+    let {
+      supported,
+      enabled,
+      isDetecting,
+      keyAorB,
+      keyToUse,
+      sector,
+      tag,
+      parsedText,
+    } = this.state;
+
+    return (
+      <ScrollView style={{ flex: 1 }}>
+        {Platform.OS === 'ios' && <View style={{ height: 60 }} />}
+
+        <View
+          style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}
+        >
+          <Text>{`Is NFC supported ? ${supported}`}</Text>
+          <Text>{`Is NFC enabled (Android only)? ${enabled}`}</Text>
+
+          {!isDetecting && (
+            <TouchableOpacity
+              style={{ margin: 10 }}
+              onPress={() => this._startDetection()}
+            >
+              <Text
+                style={{ color: 'blue', textAlign: 'center', fontSize: 20 }}
+              >
+                CLICK TO START DETECTING
+              </Text>
+            </TouchableOpacity>
+          )}
+
+          {isDetecting && (
+            <TouchableOpacity
+              style={{ margin: 10 }}
+              onPress={() => this._stopDetection()}
+            >
+              <Text style={{ color: 'red', textAlign: 'center', fontSize: 20 }}>
+                CLICK TO STOP DETECTING
+              </Text>
+            </TouchableOpacity>
+          )}
+
+          {
+            <View
+              style={{ padding: 10, marginTop: 20, backgroundColor: '#e0e0e0' }}
+            >
+              <Text>(android) Read MiFare Classic Test</Text>
+              <View style={{ flexDirection: 'row', marginTop: 10 }}>
+                <Text style={{ marginRight: 33 }}>Key to use:</Text>
+                {KeyTypes.map(key => (
+                  <TouchableOpacity
+                    key={key}
+                    style={{ marginRight: 10 }}
+                    onPress={() => this.setState({ keyAorB: key })}
+                  >
+                    <Text style={{ color: keyAorB === key ? 'blue' : '#aaa' }}>
+                      Use key {key}
+                    </Text>
+                  </TouchableOpacity>
+                ))}
+              </View>
+              <View style={{ flexDirection: 'row', alignItems: 'center' }}>
+                <Text style={{ marginRight: 35 }}>Key (hex):</Text>
+                <TextInput
+                  style={{ width: 200 }}
+                  value={keyToUse}
+                  onChangeText={keyToUse => this.setState({ keyToUse })}
+                />
+              </View>
+              <View style={{ flexDirection: 'row', alignItems: 'center' }}>
+                <Text style={{ marginRight: 10 }}>Sector (0-15):</Text>
+                <TextInput
+                  style={{ width: 200 }}
+                  value={sector.toString(10)}
+                  onChangeText={sector =>
+                    this.setState({ sector: parseInt(sector, 10) })
+                  }
+                />
+              </View>
+            </View>
+          }
+
+          <View
+            style={{
+              alignItems: 'center',
+              justifyContent: 'center',
+              padding: 20,
+              marginTop: 20,
+            }}
+          >
+            <Text>{`Original tag content:`}</Text>
+            <Text style={{ marginTop: 5, color: 'grey' }}>{`${
+              tag ? JSON.stringify(tag) : '---'
+            }`}</Text>
+            {parsedText && (
+              <Text
+                style={{ marginTop: 5 }}
+              >{`(Parsed Text: ${parsedText})`}</Text>
+            )}
+          </View>
+
+          <TouchableOpacity
+            style={{ marginTop: 20, alignItems: 'center' }}
+            onPress={this._clearMessages}
+          >
+            <Text style={{ color: 'blue' }}>Clear above message</Text>
+          </TouchableOpacity>
+        </View>
+      </ScrollView>
+    );
+  }
+
+  _startDetection = () => {
+    const cleanUp = () => {
+      this.setState({ isDetecting: false });
+      NfcManager.closeTechnology();
+      NfcManager.unregisterTagEvent();
+    };
+
+    this.setState({ isDetecting: true });
+    NfcManager.registerTagEvent(tag => console.log(tag))
+      .then(() => NfcManager.requestTechnology(NfcTech.MifareClassic))
+      .then(() => NfcManager.getTag())
+      .then(tag => {
+        this.setState({ tag });
+      })
+      .then(() => {
+        // Convert the key to a UInt8Array
+        const key = [];
+        for (let i = 0; i < this.state.keyToUse.length - 1; i += 2) {
+          key.push(parseInt(this.state.keyToUse.substring(i, i + 2), 16));
+        }
+
+        if (this.state.keyAOrB === KeyTypes[0]) {
+          return NfcManager.mifareClassicAuthenticateA(this.state.sector, key);
+        } else {
+          return NfcManager.mifareClassicAuthenticateB(this.state.sector, key);
+        }
+      })
+      .then(() => NfcManager.getMifareClassicMessage(this.state.sector))
+      .then(tag => {
+        let parsedText = ByteParser.byteToHexString(tag);
+        this.setState({ parsedText });
+      })
+      .then(cleanUp)
+      .catch(err => {
+        console.warn(err);
+        cleanUp();
+      });
+  };
+
+  _stopDetection = () => {
+    NfcManager.cancelTechnologyRequest()
+      .then(() => this.setState({ isDetecting: false }))
+      .catch(err => console.warn(err));
+  };
+
+  _startNfc = () => {
+    NfcManager.start()
+      .then(() => NfcManager.isEnabled())
+      .then(enabled => this.setState({ enabled }))
+      .catch(err => {
+        console.warn(err);
+        this.setState({ enabled: false });
+      });
+  };
+
+  _clearMessages = () => {
+    this.setState({ tag: null, parsedText: null });
+  };
+}
+
+export default App;


### PR DESCRIPTION
Hi,

As you suggested, this PR changes the usage of a string into a array of numbers (~ UInt8Array), which is more flexible and close to the card's standard. I also added an example code to demonstrate the usage (most cards have FFFFFFFFFFFF as key B so if you have a Mifare Classic card laying around you can give it a shot)

Best,
Nicolas