### PR TITLE
Feature/mifareclassic readme

### DIFF
--- a/NfcManager.js
+++ b/NfcManager.js
@@ -397,13 +397,13 @@ class NfcManager {
     })
   }
 
-  getMifareClassicMessage(sector) {
+  mifareClassicReadBlock(sector) {
     if (Platform.OS === 'ios') {
       return Promise.reject('not implemented');
     }
 
     return new Promise((resolve, reject) => {
-      NativeNfcManager.getMifareClassicMessage(sector, (err, result) => {
+      NativeNfcManager.mifareClassicReadBlock(sector, (err, result) => {
         if (err) {
           reject(err);
         } else {

--- a/README.md
+++ b/README.md
@@ -334,7 +334,7 @@ NfcManager.mifareClassicAuthenticateA(0, [0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF]).t
 });
 ```
 
-### getMifareClassicMessage(sector) [Android only]
+### mifareClassicReadBlock(sector) [Android only]
 Gets a block from a Mifare Classic card where you previously authenticated to.
 
 > This method returns a promise:
@@ -354,7 +354,7 @@ For convenience, a class `ByteParser` is included in the NfcManager exports. Thi
 __Examples__
 > A concrete example using Mifare Classic can be found in `example/AndroidMifareClassic.js`
 ```js
-NfcManager.getMifareClassicMessage(0).then((message) => {
+NfcManager.mifareClassicReadBlock(0).then((message) => {
   const str = ByteParser.byteToString(message);
   /* ...do your stuff here... */
 });
@@ -370,13 +370,13 @@ const readAuthenticatedA = async (sector, code) => {
     NfcManager.mifareClassicAuthenticateA(sector, code)
       .then(() => {
         console.log(`mifareClassicAuthenticateA(${sector}) completed`);
-        NfcManager.getMifareClassicMessage(sector)
+        NfcManager.mifareClassicReadBlock(sector)
           .then(data => {
-            console.log(`getMifareClassicMessage(${sector}) completed`);
+            console.log(`mifareClassicReadBlock(${sector}) completed`);
             resolve(data);
           })
           .catch(err => {
-            console.log(`getMifareClassicMessage(${sector}) failed:`, err);
+            console.log(`mifareClassicReadBlock(${sector}) failed:`, err);
             reject(err);
           });
       })
@@ -396,7 +396,7 @@ const sector0Data = await readAuthenticatedA(0, [0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0
 Converts a byte array `byte[]` to a hex string.
 
 __Arguments__
-- `bytes` - `byte[]` - the result of a getMifareClassicMessage call.
+- `bytes` - `byte[]` - the result of a mifareClassicReadBlock call.
 
 __Examples__
 ```js
@@ -408,7 +408,7 @@ console.log('hex string: ' + hexString);
 Converts a byte array `byte[]` to a string (if the data represents an ASCII string).
 
 __Arguments__
-- `bytes` - `byte[]` - the result of a getMifareClassicMessage call.
+- `bytes` - `byte[]` - the result of a mifareClassicReadBlock call.
 
 __Examples__
 ```js

--- a/README.md
+++ b/README.md
@@ -52,14 +52,16 @@ AppRegistry.registerComponent('NfcManagerDev', () => App);
 ```
 
 ## API
-This library provide a default export `NfcManager` and a named export `NdefParser`, like this:
+This library provide a default export `NfcManager` and 2 named exports `ByteParser` and `NdefParser`, like this:
 ```javascript
-import NfcManager, {Ndef, NdefParser} from 'react-native-nfc-manager'
+import NfcManager, {ByteParser, Ndef, NdefParser} from 'react-native-nfc-manager'
 ```
 
 All methods in `NfcManager` return a `Promise` object and are resolved to different types of data according to individual API.
 
-`Ndef` is an utility module to encode and decode some well-known NDEF format.
+* `ByteParser` is an utility module to encode and decode byte[] arrays (used in Mifare Classic technology).
+
+* `Ndef` is an utility module to encode and decode some well-known NDEF format.
 
 * `NdefParser` is an old utility class to parse some well-known NDEF format, which will be deprecated later.
 
@@ -193,7 +195,7 @@ __Arguments__
     - the available ones are defined in `NfcTech` (please do `import {NfcTech} from 'react-native-nfc-manager`) 
 
 __Examples__
-> A concrete example using NFC Technology can be found in `examples/AndroidTechTestNdef.js`
+> Concrete examples using NFC Technology can be found in `example/AndroidTechTestNdef.js` and `example/AndroidMifareClassic.js`
 
 ### cancelTechnologyRequest() [Android only]
 Cancel previous NFC Technology request. 
@@ -299,6 +301,119 @@ __Examples__
 ```js
 let text = NdefParser.parseText(sampleTag.ndefMessage[0]);
 console.log('parsedText: ' + text);
+```
+
+## Mifare Classic API [Android only]
+
+This module enables you to read encrypted [Mifare Classic](https://en.wikipedia.org/wiki/MIFARE#MIFARE_Classic_family) cards (as long as you have the authentication keys). A concrete example can be found in `example/AndroidMifareClassic.js`
+
+To find more information about the low level APIs of Mifare Classic on Android checkout this excellent blog post: [MiFare Classic Detection on Android](http://mifareclassicdetectiononandroid.blogspot.com/2011/04/reading-mifare-classic-1k-from-android.html)
+
+At the time of writing, iOS 12 still doesn't support any Mifare cards, or any NFC technology that doesn't use the NDEF standards.
+
+To use the Mifare Classic API, you first need to request the `NfcTech.MifareClassic` technology (see `requestTechnology`). Once you have the tech request, you can use the following methods to interact with the Mifare Classic cards:
+
+### mifareClassicAuthenticateA(sector, key) and mifareClassicAuthenticateB(sector, key) [Android only]
+Authenticate to the Mifare Classic card using key A or key B.
+
+> This method returns a promise:
+> * if resolved, it means you successfully authenticated to the Mifare Classic card, and a read request can be called.
+> * if rejected, it means either the request is cancelled, the discovered tag doesn't support the requested technology or the authentication simply failed. The returned error should give you some insights about what went wrong.
+
+Notice you must have successfully requested the Mifare Classic technology with the `requestTechnology` call before using this method.
+
+__Arguments__
+- `sector` - `number` - the Mifare Classic sector to authenticate to (e.g. 0 - 15 for Mifare Classic 1K cards)
+- `key` - `byte[]` - an array of bytes (numbers) that contains the key
+
+__Examples__
+> A concrete example using Mifare Classic can be found in `example/AndroidMifareClassic.js`
+```js
+NfcManager.mifareClassicAuthenticateA(0, [0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF]).then(() => {
+  /* ...do your stuff here... */
+});
+```
+
+### getMifareClassicMessage(sector) [Android only]
+Gets a block from a Mifare Classic card where you previously authenticated to.
+
+> This method returns a promise:
+> * if resolved, it returns the block (array of bytes (numbers)) from the specified sector.
+> * if rejected, it means either the request is cancelled, the discovered tag doesn't support the requested technology, the authentication failed or something else went wrong. The returned error should give you some insights about what went wrong.
+
+Notice you must be successfully authenticated with the `mifareClassicAuthenticateA` or  `mifareClassicAuthenticateB` call before using this method.
+
+__Arguments__
+- `sector` - `number` - the Mifare Classic sector to authenticate to (0 - 15) for 1K cards
+
+__Return value__
+- `block` - `byte[]` - an array of bytes (numbers)
+
+For convenience, a class `ByteParser` is included in the NfcManager exports. This class contains 2 methods `byteToHexString` and `byteToString` who can be used to get the raw data into a hex string or a string, depending on what data is stored on the card.
+
+__Examples__
+> A concrete example using Mifare Classic can be found in `example/AndroidMifareClassic.js`
+```js
+NfcManager.getMifareClassicMessage(0).then((message) => {
+  const str = ByteParser.byteToString(message);
+  /* ...do your stuff here... */
+});
+```
+
+### Read authenticated example:
+
+The following is some wrapper code that uses the `async/await` syntax.
+
+```js
+const readAuthenticatedA = async (sector, code) => {
+  return new Promise((resolve, reject) => {
+    NfcManager.mifareClassicAuthenticateA(sector, code)
+      .then(() => {
+        console.log(`mifareClassicAuthenticateA(${sector}) completed`);
+        NfcManager.getMifareClassicMessage(sector)
+          .then(data => {
+            console.log(`getMifareClassicMessage(${sector}) completed`);
+            resolve(data);
+          })
+          .catch(err => {
+            console.log(`getMifareClassicMessage(${sector}) failed:`, err);
+            reject(err);
+          });
+      })
+      .catch(err => {
+        console.log(`mifareClassicAuthenticateA(${sector}) failed:`, err);
+        reject(err);
+      });
+  });
+};
+
+const sector0Data = await readAuthenticatedA(0, [0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF]);
+```
+
+## ByteParser API (simple utility for working with byte[] arrays like in Mifare Classic cards)
+
+### byteToHexString(bytes)
+Converts a byte array `byte[]` to a hex string.
+
+__Arguments__
+- `bytes` - `byte[]` - the result of a getMifareClassicMessage call.
+
+__Examples__
+```js
+let hexString = ByteParser.byteToHexString(result);
+console.log('hex string: ' + hexString);
+```
+
+### byteToString(bytes)
+Converts a byte array `byte[]` to a string (if the data represents an ASCII string).
+
+__Arguments__
+- `bytes` - `byte[]` - the result of a getMifareClassicMessage call.
+
+__Examples__
+```js
+let str = ByteParser.byteToString(result);
+console.log('string: ' + str);
 ```
 
 ## NFC Hardware requirement on Android

--- a/android/src/main/java/community/revteltech/nfc/NfcManager.java
+++ b/android/src/main/java/community/revteltech/nfc/NfcManager.java
@@ -244,7 +244,14 @@ class NfcManager extends ReactContextBaseJavaModule implements ActivityEventList
 					return;
 				}
 
-				if (!mifareTag.authenticateSectorWithKeyA(sector, readableArrayToBytes(key))) {
+				boolean result = false;
+				if (type == 'A') {
+					result = mifareTag.authenticateSectorWithKeyA(sector, readableArrayToBytes(key));
+				} else {
+					result = mifareTag.authenticateSectorWithKeyB(sector, readableArrayToBytes(key));
+				}
+
+				if (!result) {
 					callback.invoke("mifareClassicAuthenticate fail: AUTH_FAIL");
 					return;
 				}

--- a/android/src/main/java/community/revteltech/nfc/NfcManager.java
+++ b/android/src/main/java/community/revteltech/nfc/NfcManager.java
@@ -251,9 +251,9 @@ class NfcManager extends ReactContextBaseJavaModule implements ActivityEventList
 
 				callback.invoke(null, true);
 			} catch (TagLostException ex) {
-				callback.invoke("getMifareClassicMessage fail: TAG_LOST");
+				callback.invoke("mifareClassicAuthenticate fail: TAG_LOST");
 			} catch (Exception ex) {
-				callback.invoke("getMifareClassicMessage fail: " + ex.toString());
+				callback.invoke("mifareClassicAuthenticate fail: " + ex.toString());
 			}
 		} else {
 			callback.invoke("no tech request available");
@@ -275,7 +275,7 @@ class NfcManager extends ReactContextBaseJavaModule implements ActivityEventList
 	}
 
 	@ReactMethod
-	public void getMifareClassicMessage(int sector, Callback callback) {
+	public void mifareClassicReadBlock(int sector, Callback callback) {
 		synchronized(this) {
 			if (techRequest != null) {
 				MifareClassic mifareTag = null;
@@ -285,11 +285,11 @@ class NfcManager extends ReactContextBaseJavaModule implements ActivityEventList
 					mifareTag = MifareClassic.get(tag);
 					if (mifareTag == null || mifareTag.getType() == MifareClassic.TYPE_UNKNOWN) {
 						// Not a mifare card, fail
-						callback.invoke("getMifareClassicMessage fail: TYPE_UNKNOWN");
+						callback.invoke("mifareClassicReadBlock fail: TYPE_UNKNOWN");
 						return;
 					} else if (sector >= mifareTag.getSectorCount()) {
 						// Not a mifare card, fail
-						String msg = String.format("getMifareClassicMessage fail: invalid sector %d (max %d)", sector, mifareTag.getSectorCount());
+						String msg = String.format("mifareClassicReadBlock fail: invalid sector %d (max %d)", sector, mifareTag.getSectorCount());
 						callback.invoke(msg);
 						return;
 					}
@@ -304,9 +304,9 @@ class NfcManager extends ReactContextBaseJavaModule implements ActivityEventList
 
 					callback.invoke(null, result);
 				} catch (TagLostException ex) {
-					callback.invoke("getMifareClassicMessage fail: TAG_LOST");
+					callback.invoke("mifareClassicReadBlock fail: TAG_LOST");
 				} catch (Exception ex) {
-					callback.invoke("getMifareClassicMessage fail: " + ex.toString());
+					callback.invoke("mifareClassicReadBlock fail: " + ex.toString());
 				}
 			} else {
 				callback.invoke("no tech request available");

--- a/example/AndroidMifareClassic.js
+++ b/example/AndroidMifareClassic.js
@@ -21,7 +21,7 @@ class App extends Component {
       keyAorB: KeyTypes[1], // 'B'
       keyToUse: 'FFFFFFFFFFFF',
       sector: 0,
-      tag: {},
+      tag: null,
       parsedText: null,
     };
   }
@@ -120,7 +120,7 @@ class App extends Component {
                   style={{ width: 200 }}
                   value={sector.toString(10)}
                   onChangeText={sector =>
-                    this.setState({ sector: parseInt(sector, 10) })
+                    this.setState({ sector: sector })
                   }
                 />
               </View>
@@ -172,19 +172,25 @@ class App extends Component {
         this.setState({ tag });
       })
       .then(() => {
+        let sector = parseInt(this.state.sector);
+        if (isNaN(sector)) {
+          this.setState({ sector: '0' });
+          sector = 0;
+        }
+
         // Convert the key to a UInt8Array
         const key = [];
         for (let i = 0; i < this.state.keyToUse.length - 1; i += 2) {
           key.push(parseInt(this.state.keyToUse.substring(i, i + 2), 16));
         }
 
-        if (this.state.keyAOrB === KeyTypes[0]) {
-          return NfcManager.mifareClassicAuthenticateA(this.state.sector, key);
+        if (this.state.keyAorB === KeyTypes[0]) {
+          return NfcManager.mifareClassicAuthenticateA(sector, key);
         } else {
-          return NfcManager.mifareClassicAuthenticateB(this.state.sector, key);
+          return NfcManager.mifareClassicAuthenticateB(sector, key);
         }
       })
-      .then(() => NfcManager.mifareClassicReadBlock(this.state.sector))
+      .then(() => NfcManager.mifareClassicReadBlock(parseInt(this.state.sector)))
       .then(tag => {
         let parsedText = ByteParser.byteToHexString(tag);
         this.setState({ parsedText });

--- a/example/AndroidMifareClassic.js
+++ b/example/AndroidMifareClassic.js
@@ -184,7 +184,7 @@ class App extends Component {
           return NfcManager.mifareClassicAuthenticateB(this.state.sector, key);
         }
       })
-      .then(() => NfcManager.getMifareClassicMessage(this.state.sector))
+      .then(() => NfcManager.mifareClassicReadBlock(this.state.sector))
       .then(tag => {
         let parsedText = ByteParser.byteToHexString(tag);
         this.setState({ parsedText });

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "nfc"
   ],
   "files": [
+    "ByteParser.js",
     "NfcManager.js",
     "NdefParser.js",
     "ndef-lib",


### PR DESCRIPTION
# Changes
- Added documentation  in README.md
- Renamed getMifareClassicMessage to mifareClassicReadBlock to have a bit more consistency
- Fixed a bug in mifareClassicAuthenticate (it was always authenticating to key A)
- Some fixes on the example app
- Added ByteParser.js in package.json