### PR TITLE
Catch exception during NFCNDEFReaderSession.readingAvailable

### DIFF
--- a/ios/NfcManager.m
+++ b/ios/NfcManager.m
@@ -2,6 +2,7 @@
 #import "React/RCTBridge.h"
 #import "React/RCTConvert.h"
 #import "React/RCTEventDispatcher.h"
+#import "React/RCTLog.h"
 
 int isSupported() {
     bool result = NO;

--- a/ios/NfcManager.m
+++ b/ios/NfcManager.m
@@ -6,8 +6,13 @@
 int isSupported() {
     bool result = NO;
     if (@available(iOS 11.0, *)) {
-        if (NFCNDEFReaderSession.readingAvailable) {
-            result = YES;
+        @try {
+            if (NFCNDEFReaderSession.readingAvailable) {
+                result = YES;
+            }
+        }
+        @catch (NSException *exception) {
+            RCTLogError(@"Exception thrown during NfcManager.isSupported: %@", exception);
         }
     }
     return result;


### PR DESCRIPTION
Closes #112 

Handles sporadic
```
Crashed: com.facebook.react.NfcManagerQueue
EXC_BAD_ACCESS KERN_INVALID_ADDRESS 0x50435f4462f88092
```
in iOS