### PR TITLE
Feature/issupported tech

### DIFF
--- a/NfcManager.js
+++ b/NfcManager.js
@@ -70,9 +70,9 @@ class NfcManager {
     return Promise.resolve();
   }
 
-  isSupported(){
+  isSupported(tech = ''){
     return new Promise((resolve, reject) => {
-      NativeNfcManager.isSupported((err,result) => {
+      NativeNfcManager.isSupported(tech, (err,result) => {
         if (err) {
           reject(err);
         } else {

--- a/README.md
+++ b/README.md
@@ -101,9 +101,21 @@ NfcManager.start({
 ### stop()
 Terminates the module. This will remove the onSessionClosedIOS listener that is attached in the `start` function.
 
-### isSupported() 
-Chck if the NFC is supported by hardware.
-Returned `Promise` resolved to a boolean value to indicate whether NFC is supported.
+### isSupported(tech = '')
+Check if NFC (and specified NFC technology) is supported by the hardware.
+When you specify a technology, some extra checks are performed to see if the technology is supported or not.
+Returnes `Promise` resolved to a boolean value to indicate whether NFC (and specified NFC technology) is supported.
+
+__Arguments__
+- `tech` - `string` - optional parameter, use a constant of the NfcTech class, defaults to ''
+
+__Examples__
+```js
+NfcManager.isSupported(NfcTech.MifareClassic)
+    .then(() => console.log('Mifare classic is supported'))
+    .catch(err => console.warn(err))
+```
+
 
 ### isEnabled() [Android only]
 Check if the NFC is enabled.

--- a/android/src/main/java/community/revteltech/nfc/MifareUtil.java
+++ b/android/src/main/java/community/revteltech/nfc/MifareUtil.java
@@ -1,0 +1,84 @@
+package community.revteltech.nfc;
+
+import android.app.Activity;
+import android.content.pm.PackageManager;
+import android.os.Build;
+
+import java.io.File;
+import java.util.*;
+import java.nio.charset.Charset;
+
+class MifareUtil {
+	/**
+	 * Checks if Mifare is supported on a device with some heuristics.
+	 * Will _try_ to detect if Mifare is supported on a device or not. Please note that it's not fool-proof: I've
+	 * seen on some older devices (Samsung Galaxy S4) the method returning true, while we can only detect it fails
+	 * when a tag is scanned. Unfortunately there's nothing to do about it. But still it's a good effort and a
+	 * better approach than blacklisting devices imho.
+	 *
+	 * Credits: ikarus23 (https://github.com/ikarus23/MifareClassicTool)
+	 * @see https://github.com/ikarus23/MifareClassicTool/blob/master/Mifare%20Classic%20Tool/app/src/main/java/de/syss/MifareClassicTool/Common.java#L588
+	 * @see https://github.com/ikarus23/MifareClassicTool/blob/master/INCOMPATIBLE_DEVICES.md
+	 *
+	 * @param  currentActivity  The activity (should be passed since this is a static utility method).
+	 * @return The fact if a device is supported or not.
+	 */
+	public static boolean isDeviceSupported(Activity currentActivity) {
+		if (currentActivity == null) {
+			return false;
+		}
+
+		if (!currentActivity.getPackageManager().hasSystemFeature(PackageManager.FEATURE_NFC)) {
+			return false;
+		}
+
+		boolean foundViaFeatures = currentActivity.getPackageManager().hasSystemFeature("com.nxp.mifare");
+		if (!foundViaFeatures) {
+			return false;
+		}
+
+		// The following code is thanks to ikarus23's MifareClassicTool (https://github.com/ikarus23/MifareClassicTool)
+		// @see https://github.com/ikarus23/MifareClassicTool/blob/3eb37b0afa3f57f0d18f2fcdfcee2435b47886d8/Mifare%20Classic%20Tool/app/src/main/java/de/syss/MifareClassicTool/Common.java#L588
+
+		// Check if there is the NFC device "bcm2079x-i2c".
+		// Chips by Broadcom don't support MIFARE Classic.
+		// This could fail because on a lot of devices apps don't have
+		// the sufficient permissions.
+		// Another exception:
+		// The Lenovo P2 has a device at "/dev/bcm2079x-i2c" but is still
+		// able of reading/writing MIFARE Classic tags. I don't know why...
+		// https://github.com/ikarus23/MifareClassicTool/issues/152
+		boolean isLenovoP2 = Build.MANUFACTURER.equals("LENOVO")
+			&& Build.MODEL.equals("Lenovo P2a42");
+		File device = new File("/dev/bcm2079x-i2c");
+		if (!isLenovoP2 && device.exists()) {
+			return false;
+		}
+
+		// Check if there is the NFC device "pn544".
+		// The PN544 NFC chip is manufactured by NXP.
+		// Chips by NXP support MIFARE Classic.
+		device = new File("/dev/pn544");
+		if (device.exists()) {
+			return true;
+		}
+
+		// Check if there are NFC libs with "brcm" in their names.
+		// "brcm" libs are for devices with Broadcom chips. Broadcom chips
+		// don't support MIFARE Classic.
+		File libsFolder = new File("/system/lib");
+		File[] libs = libsFolder.listFiles();
+		for (File lib : libs) {
+			if (lib.isFile()
+				&& lib.getName().startsWith("libnfc")
+				&& lib.getName().contains("brcm")
+				// Add here other non NXP NFC libraries.
+			) {
+				return false;
+			}
+		}
+
+		// We don't have reason to believe that it's not supported, or we can't detect it right now (we should wait when a tag is connected and do then some heuristics)
+		return true;
+	}
+}

--- a/android/src/main/java/community/revteltech/nfc/NfcManager.java
+++ b/android/src/main/java/community/revteltech/nfc/NfcManager.java
@@ -702,57 +702,13 @@ class NfcManager extends ReactContextBaseJavaModule implements ActivityEventList
 			return;
 		}
 
-		// If we ask for MifareClassic support, so some extra checks
-		// NOTE: since not all chips and devices are compatible with MifareClassic we do need this code
+		// If we ask for MifareClassic support, so some extra checks, since not all chips and devices are
+		// compatible with MifareClassic
+		// TODO: Check if it's the same case with MifareUltralight
 		if (tech.equals("MifareClassic")) {
-			boolean foundViaFeatures = currentActivity.getPackageManager().hasSystemFeature("com.nxp.mifare");
-			if (!foundViaFeatures) {
+			if (!MifareUtil.isDeviceSupported(currentActivity)) {
 				callback.invoke(null, false);
 				return;
-			}
-
-			// The following code is thanks to ikarus23's MifareClassicTool (https://github.com/ikarus23/MifareClassicTool)
-			// @see https://github.com/ikarus23/MifareClassicTool/blob/3eb37b0afa3f57f0d18f2fcdfcee2435b47886d8/Mifare%20Classic%20Tool/app/src/main/java/de/syss/MifareClassicTool/Common.java#L588
-
-			// Check if there is the NFC device "bcm2079x-i2c".
-			// Chips by Broadcom don't support MIFARE Classic.
-			// This could fail because on a lot of devices apps don't have
-			// the sufficient permissions.
-			// Another exception:
-			// The Lenovo P2 has a device at "/dev/bcm2079x-i2c" but is still
-			// able of reading/writing MIFARE Classic tags. I don't know why...
-			// https://github.com/ikarus23/MifareClassicTool/issues/152
-			boolean isLenovoP2 = Build.MANUFACTURER.equals("LENOVO")
-				&& Build.MODEL.equals("Lenovo P2a42");
-			File device = new File("/dev/bcm2079x-i2c");
-			if (!isLenovoP2 && device.exists()) {
-				callback.invoke(null, false);
-				return;
-			}
-
-			// Check if there is the NFC device "pn544".
-			// The PN544 NFC chip is manufactured by NXP.
-			// Chips by NXP support MIFARE Classic.
-			device = new File("/dev/pn544");
-			if (device.exists()) {
-				callback.invoke(null, true);
-				return;
-			}
-
-			// Check if there are NFC libs with "brcm" in their names.
-			// "brcm" libs are for devices with Broadcom chips. Broadcom chips
-			// don't support MIFARE Classic.
-			File libsFolder = new File("/system/lib");
-			File[] libs = libsFolder.listFiles();
-			for (File lib : libs) {
-				if (lib.isFile()
-					&& lib.getName().startsWith("libnfc")
-					&& lib.getName().contains("brcm")
-					// Add here other non NXP NFC libraries.
-				) {
-					callback.invoke(null, false);
-					return;
-				}
 			}
 		}
 

--- a/android/src/main/java/community/revteltech/nfc/NfcManager.java
+++ b/android/src/main/java/community/revteltech/nfc/NfcManager.java
@@ -687,9 +687,9 @@ class NfcManager extends ReactContextBaseJavaModule implements ActivityEventList
 	}
     
    	@ReactMethod
-	public void isSupported(Callback callback){
+	public void isSupported(String tech, Callback callback){
 		Log.d(LOG_TAG, "isSupported");
-        Activity currentActivity = getCurrentActivity();
+		Activity currentActivity = getCurrentActivity();
 		if (currentActivity == null) {
 			callback.invoke("fail to get current activity");
 			return;

--- a/android/src/main/java/community/revteltech/nfc/NfcManager.java
+++ b/android/src/main/java/community/revteltech/nfc/NfcManager.java
@@ -41,6 +41,7 @@ import android.os.Parcelable;
 import org.json.JSONObject;
 import org.json.JSONException;
 
+import java.io.File;
 import java.util.*;
 import java.nio.charset.Charset;
 
@@ -48,6 +49,7 @@ import static android.app.Activity.RESULT_OK;
 import static android.os.Build.VERSION_CODES.LOLLIPOP;
 import static com.facebook.react.bridge.UiThreadUtil.runOnUiThread;
 
+import android.content.pm.FeatureInfo;
 import android.content.pm.PackageManager;
 
 class NfcManager extends ReactContextBaseJavaModule implements ActivityEventListener, LifecycleEventListener {
@@ -695,8 +697,66 @@ class NfcManager extends ReactContextBaseJavaModule implements ActivityEventList
 			return;
 		}
 
-		boolean result = currentActivity.getPackageManager().hasSystemFeature(PackageManager.FEATURE_NFC);
-		callback.invoke(null, result);
+		if (!currentActivity.getPackageManager().hasSystemFeature(PackageManager.FEATURE_NFC)) {
+			callback.invoke(null, false);
+			return;
+		}
+
+		// If we ask for MifareClassic support, so some extra checks
+		// NOTE: since not all chips and devices are compatible with MifareClassic we do need this code
+		if (tech.equals("MifareClassic")) {
+			boolean foundViaFeatures = currentActivity.getPackageManager().hasSystemFeature("com.nxp.mifare");
+			if (!foundViaFeatures) {
+				callback.invoke(null, false);
+				return;
+			}
+
+			// The following code is thanks to ikarus23's MifareClassicTool (https://github.com/ikarus23/MifareClassicTool)
+			// @see https://github.com/ikarus23/MifareClassicTool/blob/3eb37b0afa3f57f0d18f2fcdfcee2435b47886d8/Mifare%20Classic%20Tool/app/src/main/java/de/syss/MifareClassicTool/Common.java#L588
+
+			// Check if there is the NFC device "bcm2079x-i2c".
+			// Chips by Broadcom don't support MIFARE Classic.
+			// This could fail because on a lot of devices apps don't have
+			// the sufficient permissions.
+			// Another exception:
+			// The Lenovo P2 has a device at "/dev/bcm2079x-i2c" but is still
+			// able of reading/writing MIFARE Classic tags. I don't know why...
+			// https://github.com/ikarus23/MifareClassicTool/issues/152
+			boolean isLenovoP2 = Build.MANUFACTURER.equals("LENOVO")
+				&& Build.MODEL.equals("Lenovo P2a42");
+			File device = new File("/dev/bcm2079x-i2c");
+			if (!isLenovoP2 && device.exists()) {
+				callback.invoke(null, false);
+				return;
+			}
+
+			// Check if there is the NFC device "pn544".
+			// The PN544 NFC chip is manufactured by NXP.
+			// Chips by NXP support MIFARE Classic.
+			device = new File("/dev/pn544");
+			if (device.exists()) {
+				callback.invoke(null, true);
+				return;
+			}
+
+			// Check if there are NFC libs with "brcm" in their names.
+			// "brcm" libs are for devices with Broadcom chips. Broadcom chips
+			// don't support MIFARE Classic.
+			File libsFolder = new File("/system/lib");
+			File[] libs = libsFolder.listFiles();
+			for (File lib : libs) {
+				if (lib.isFile()
+					&& lib.getName().startsWith("libnfc")
+					&& lib.getName().contains("brcm")
+					// Add here other non NXP NFC libraries.
+				) {
+					callback.invoke(null, false);
+					return;
+				}
+			}
+		}
+
+		callback.invoke(null, true);
 	}
 
 	@ReactMethod

--- a/example/AndroidMifareClassic.js
+++ b/example/AndroidMifareClassic.js
@@ -32,7 +32,7 @@ class App extends Component {
   }
 
   componentDidMount() {
-    NfcManager.isSupported().then(supported => {
+    NfcManager.isSupported(NfcTech.MifareClassic).then(supported => {
       this.setState({ supported });
       if (supported) {
         this._startNfc();
@@ -69,7 +69,7 @@ class App extends Component {
         <View
           style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}
         >
-          <Text>{`Is NFC supported ? ${supported}`}</Text>
+          <Text>{`Is MifareClassic supported ? ${supported}`}</Text>
           <Text>{`Is NFC enabled (Android only)? ${enabled}`}</Text>
 
           {!isDetecting && (

--- a/ios/NfcManager.m
+++ b/ios/NfcManager.m
@@ -105,13 +105,17 @@ RCT_EXPORT_MODULE()
     return YES;
 }
 
-RCT_EXPORT_METHOD(isSupported: (nonnull RCTResponseSenderBlock)callback)
+RCT_EXPORT_METHOD(isSupported: (NSString *)tech callback:(nonnull RCTResponseSenderBlock)callback)
 {
     if (isSupported()) {
-        callback(@[[NSNull null], @YES]);
-    } else {
-        callback(@[[NSNull null], @NO]);
+        // iOS only supports Ndef starting from iOS 11.0 (on iPhone 7 onwards)
+        if ([tech isEqualToString:@""] || [tech isEqualToString:@"Ndef"]) {
+            callback(@[[NSNull null], @YES]);
+            return;
+        }
     }
+
+    callback(@[[NSNull null], @NO]);
 }
 
 RCT_EXPORT_METHOD(start: (nonnull RCTResponseSenderBlock)callback)


### PR DESCRIPTION
## Added
After some big testing on various android devices, I found out that not every device supports every technology. After doing some research I found the following:
- on some devices, you can know on forehand if Mifare is supported, that's why I extended the `isSupported` method
- on other devices, you only know that Mifare is unsupported if you can't connect to the tag, nothing to do about this

Please let me know what you think

Best,
Nicolas