### PR TITLE
Added support for `NfcAdapter.enableReaderMode`

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,13 +134,23 @@ Start to listen to *ANY* NFC tags.
 __Arguments__
 - `listener` - `function` - the callback when discovering NFC tags
 - `alertMessage` - `string` - (iOS) the message to display on iOS when the NFCScanning pops up
-- `invalidateAfterFirstRead` - `boolean` - (iOS) when set to true this will not have you prompt to click done after NFC Scan.
+- `options` - `object` - Object containing (iOS)invalidateAfterFirstRead, (Android)isReaderModeEnabled, (Android)readerModeFlags. Use `NfcAdapter` flags. **Reader mode can only be used in Android 19 or later**.
 
-__Examples__
+**Examples**
+
 ```js
-NfcManager.registerTagEvent(tag => {
+NfcManager.registerTagEvent(
+  tag => {
     console.log('Tag Discovered', tag);
-}, 'Hold your device over the tag', true)
+  },
+  'Hold your device over the tag',
+  {
+    invalidateAfterFirstRead: true,
+    isReaderModeEnabled: true,
+    readerModeFlags:
+      NfcAdapter.FLAG_READER_NFC_A | NfcAdapter.FLAG_READER_SKIP_NDEF_CHECK,
+  },
+);
 ```
 
 ### unregisterTagEvent()

--- a/android/src/main/java/community/revteltech/nfc/NfcManager.java
+++ b/android/src/main/java/community/revteltech/nfc/NfcManager.java
@@ -775,7 +775,6 @@ class NfcManager extends ReactContextBaseJavaModule implements ActivityEventList
     private void unregisterTagEvent(Callback callback) {
         Log.d(LOG_TAG, "registerTag");
 		isForegroundEnabled = false;
-		isReaderModeEnabled = false;
 		intentFilters.clear();
 		if (isResumed) {
 			enableDisableForegroundDispatch(false);
@@ -841,6 +840,7 @@ class NfcManager extends ReactContextBaseJavaModule implements ActivityEventList
 						}, readerModeFlags, null);
 					} else {
 						nfcAdapter.disableReaderMode(currentActivity);
+						isReaderModeEnabled = false;
 					}
 				} else {
 					if (enable) {

--- a/android/src/main/java/community/revteltech/nfc/NfcManager.java
+++ b/android/src/main/java/community/revteltech/nfc/NfcManager.java
@@ -5,25 +5,19 @@ import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
+import android.content.pm.PackageManager;
 import android.os.Build;
-import android.os.Bundle;
 import android.support.annotation.Nullable;
-import android.util.Base64;
 import android.util.Log;
 import android.provider.Settings;
 import com.facebook.react.bridge.*;
 import com.facebook.react.modules.core.RCTNativeAppEventEmitter;
 
 import android.app.PendingIntent;
-import android.content.Intent;
-import android.content.IntentFilter;
 import android.content.IntentFilter.MalformedMimeTypeException;
-import android.net.Uri;
 import android.nfc.FormatException;
 import android.nfc.NdefMessage;
-import android.nfc.NdefRecord;
 import android.nfc.NfcAdapter;
-import android.nfc.NfcEvent;
 import android.nfc.Tag;
 import android.nfc.TagLostException;
 import android.nfc.tech.TagTechnology;
@@ -41,16 +35,7 @@ import android.os.Parcelable;
 import org.json.JSONObject;
 import org.json.JSONException;
 
-import java.io.File;
 import java.util.*;
-import java.nio.charset.Charset;
-
-import static android.app.Activity.RESULT_OK;
-import static android.os.Build.VERSION_CODES.LOLLIPOP;
-import static com.facebook.react.bridge.UiThreadUtil.runOnUiThread;
-
-import android.content.pm.FeatureInfo;
-import android.content.pm.PackageManager;
 
 class NfcManager extends ReactContextBaseJavaModule implements ActivityEventListener, LifecycleEventListener {
 	private static final String LOG_TAG = "ReactNativeNfcManager";
@@ -62,6 +47,10 @@ class NfcManager extends ReactContextBaseJavaModule implements ActivityEventList
 	private Boolean isResumed = false;
 	private WriteNdefRequest writeNdefRequest = null;
 	private TagTechnologyRequest techRequest = null;
+
+	// Use NFC reader mode instead of listening to a dispatch
+	private Boolean isReaderModeEnabled = false;
+	private int readerModeFlags = 0;
 
 	class WriteNdefRequest {
 		NdefMessage message;
@@ -753,8 +742,11 @@ class NfcManager extends ReactContextBaseJavaModule implements ActivityEventList
 	}
 
 	@ReactMethod
-    private void registerTagEvent(String alertMessage, Boolean invalidateAfterFirstRead, Callback callback) {
-        Log.d(LOG_TAG, "registerTag");
+    private void registerTagEvent(String alertMessage, ReadableMap options, Callback callback) {
+		this.isReaderModeEnabled = options.getBoolean("isReaderModeEnabled");
+		this.readerModeFlags = options.getInt("readerModeFlags");
+
+		Log.d(LOG_TAG, "registerTag");
 		isForegroundEnabled = true;
 
 		// capture all mime-based dispatch NDEF
@@ -783,6 +775,7 @@ class NfcManager extends ReactContextBaseJavaModule implements ActivityEventList
     private void unregisterTagEvent(Callback callback) {
         Log.d(LOG_TAG, "registerTag");
 		isForegroundEnabled = false;
+		isReaderModeEnabled = false;
 		intentFilters.clear();
 		if (isResumed) {
 			enableDisableForegroundDispatch(false);
@@ -818,10 +811,43 @@ class NfcManager extends ReactContextBaseJavaModule implements ActivityEventList
 
         if (nfcAdapter != null && currentActivity != null && !currentActivity.isFinishing()) {
             try {
-				if (enable) {
-                    nfcAdapter.enableForegroundDispatch(currentActivity, getPendingIntent(), getIntentFilters(), getTechLists());
+            	if (isReaderModeEnabled) {
+            		if (Build.VERSION.SDK_INT < Build.VERSION_CODES.HONEYCOMB) {
+						throw new RuntimeException("minSdkVersion must be Honeycomb (19) or later.");
+					}
+
+					if (enable) {
+						nfcAdapter.enableReaderMode(currentActivity, new NfcAdapter.ReaderCallback() {
+							@Override
+							public void onTagDiscovered(Tag tag) {
+								WritableMap nfcTag = null;
+								for (String tagTech : tag.getTechList()) {
+									Log.d(LOG_TAG, tagTech);
+									if (tagTech.equals(NdefFormatable.class.getName())) {
+										// fireNdefFormatableEvent(tag);
+										nfcTag = tag2React(tag);
+									} else if (tagTech.equals(Ndef.class.getName())) { //
+										Ndef ndef = Ndef.get(tag);
+										nfcTag = ndef2React(ndef, new NdefMessage[] { ndef.getCachedNdefMessage() });
+									} else {
+										nfcTag = tag2React(tag);
+									}
+								}
+
+								if (nfcTag != null) {
+									sendEvent("NfcManagerDiscoverTag", nfcTag);
+								}
+							}
+						}, readerModeFlags, null);
+					} else {
+						nfcAdapter.disableReaderMode(currentActivity);
+					}
 				} else {
-					nfcAdapter.disableForegroundDispatch(currentActivity);
+					if (enable) {
+						nfcAdapter.enableForegroundDispatch(currentActivity, getPendingIntent(), getIntentFilters(), getTechLists());
+					} else {
+						nfcAdapter.disableForegroundDispatch(currentActivity);
+					}
 				}
             } catch (IllegalStateException | NullPointerException e) {
                 Log.w(LOG_TAG, "Illegal State Exception starting NFC. Assuming application is terminating.");

--- a/android/src/main/java/community/revteltech/nfc/NfcManager.java
+++ b/android/src/main/java/community/revteltech/nfc/NfcManager.java
@@ -840,7 +840,6 @@ class NfcManager extends ReactContextBaseJavaModule implements ActivityEventList
 						}, readerModeFlags, null);
 					} else {
 						nfcAdapter.disableReaderMode(currentActivity);
-						isReaderModeEnabled = false;
 					}
 				} else {
 					if (enable) {

--- a/index.d.ts
+++ b/index.d.ts
@@ -28,6 +28,12 @@ declare module 'react-native-nfc-manager' {
 		id: number[];
 	}
 
+	interface RegisterTagEventOpts {
+    invalidateAfterFirstRead: boolean;
+    isReaderModeEnabled: boolean;
+    readerModeFlags: number;
+  }
+
 	interface NdefWriteOpts {
 		format?: boolean
 		formatReadOnly?: boolean
@@ -52,16 +58,16 @@ declare module 'react-native-nfc-manager' {
 		/** [ANDROID ONLY] */
 		getLaunchTagEvent(): Promise<TagEvent | null>;
 
-		/**
-		 * Start to listen to ANY NFC Tags
-		 * @param listener The callback function when a tag is found.
-		 * @param alertMessage [iOS ONLY] Message displayed when NFC Scanning popup appears.
-		 * @param invalidateAfterFirstRead [iOS ONLY] When set to true, will auto-dismiss the NFC Scanning popup after scanning.
-		 */
-		registerTagEvent(
-			listener: (tag: TagEvent) => void,
-			alertMessage?: string,
-			invalidateAfterFirstRead?: boolean
+		 /**
+     * Start to listen to ANY NFC Tags
+     * @param listener The callback function when a tag is found.
+     * @param alertMessage [iOS ONLY] Message displayed when NFC Scanning popup appears.
+     * @param invalidateAfterFirstRead [iOS ONLY] When set to true, will auto-dismiss the NFC Scanning popup after scanning.
+     */
+    registerTagEvent(
+      listener: (tag: TagEvent) => void,
+      alertMessage?: string,
+      options?: RegisterTagEventOpts,
 		): Promise<any>;
 
 		unregisterTagEvent(): Promise<any>;

--- a/ios/NfcManager.m
+++ b/ios/NfcManager.m
@@ -129,10 +129,11 @@ RCT_EXPORT_METHOD(start: (nonnull RCTResponseSenderBlock)callback)
     }
 }
 
-RCT_EXPORT_METHOD(registerTagEvent: (NSString *)alertMessage invalidateAfterFirstRead:(BOOL)invalidateAfterFirstRead callback:(nonnull RCTResponseSenderBlock)callback)
+RCT_EXPORT_METHOD(registerTagEvent: (NSString *)alertMessage options:(NSDictionary)options callback:(nonnull RCTResponseSenderBlock)callback)
 {
     if (@available(iOS 11.0, *)) {
         if (session == nil) {
+            BOOL invalidateAfterFirstRead = [[options objectForKey:@"invalidateAfterFirstRead"] boolValue];
             session = [[NFCNDEFReaderSession alloc] initWithDelegate:self queue:dispatch_get_main_queue() invalidateAfterFirstRead:invalidateAfterFirstRead];
             session.alertMessage = alertMessage;
             [session beginSession];


### PR DESCRIPTION
`enableForegroundDispatch` listens for all types of tag events and doesn't work well for my use-cases. With this you can now fine-tune the types of tags and NFC actions the reader listens to.

---

I don't know Objective-C and didn't test the changes there. It would be great if someone could compile/test this.