### PR TITLE
Fixed id_length in decodeMessage.

### DIFF
--- a/ndef-lib/index.js
+++ b/ndef-lib/index.js
@@ -313,9 +313,7 @@ var ndef = {
                     (0xFF & bytes.shift());
             }
 
-            if (header.il) {
-                id_length = bytes.shift();
-            }
+            id_length = header.il ? bytes.shift() : 0;
 
             record_type = bytes.splice(0, type_length);
             id = bytes.splice(0, id_length);


### PR DESCRIPTION
When there is a record with `header.il === false`, in the variable `id_length` will remain a value from the previous record (previous while cycle). In some situations it could result in malformed records that follows an record with `header.il === false`.