### PR TITLE
Fixed NfcManager.stop()

### DIFF
--- a/NfcManager.js
+++ b/NfcManager.js
@@ -81,8 +81,10 @@ class NfcManager {
   }
 
   stop() {
-    this._session.remove();
-    this._session = null;
+    if (this._session) {
+      this._session.remove();
+      this._session = null;
+    }
     return Promise.resolve();
   }
 

--- a/NfcManager.js
+++ b/NfcManager.js
@@ -50,6 +50,7 @@ class NfcManager {
   constructor() {
     this._clientTagDiscoveryListener = null;
     this._clientSessionClosedListener = null;
+    this._session = null;
     this._subscription = null;
   }
 


### PR DESCRIPTION
An invocation of `NfcManager.stop()` shouldn't throw an error when `NfcManager.start()` hasn't been called or has failed.