### PR TITLE
Wifi support for writing nfc

### DIFF
--- a/ndef-lib/index.js
+++ b/ndef-lib/index.js
@@ -5,7 +5,8 @@
 
 var util = require('./ndef-util'),
     textHelper = require('./ndef-text'),
-    uriHelper = require('./ndef-uri');
+    uriHelper = require('./ndef-uri'),
+    wifiHelper = require('./ndef-wifi');
 
 var ndef = {
 
@@ -27,6 +28,8 @@ var ndef = {
     RTD_HANDOVER_CARRIER: "Hc", // [0x48, 0x63]
     RTD_HANDOVER_REQUEST: "Hr", // [0x48, 0x72]
     RTD_HANDOVER_SELECT: "Hs", // [0x48, 0x73]
+    
+    NFC_TOKEN_MIME_TYPE: "application/vnd.wfa.wsc", //mimetype for wifi credentials
 
     /**
      * Creates a JSON representation of a NDEF Record.
@@ -110,6 +113,18 @@ var ndef = {
         var payload = uriHelper.encodePayload(uri);
         if (!id) { id = []; }
         return ndef.record(ndef.TNF_WELL_KNOWN, ndef.RTD_URI, id, payload);
+    },
+
+    /**
+     * Helper that creates a NDEF record containing wifi credentials
+     *
+     * @credentials Object with ssid, 
+     * @id byte[] (optional)
+     */
+    wifiRecord: function(credentials, id) {
+      var payload = wifiHelper.encodePayload(credentials);
+      if (!id) { id = []; }
+      return ndef.record(ndef.TNF_MIME_MEDIA, ndef.NFC_TOKEN_MIME_TYPE, id, payload);
     },
 
     /**
@@ -563,6 +578,7 @@ function s(bytes) {
 // expose helper objects
 ndef.text = textHelper;
 ndef.uri = uriHelper;
+ndef.wifi = wifiHelper;
 ndef.tnfToString = tnfToString;
 ndef.util = util;
 ndef.stringify = stringifier.stringify;

--- a/ndef-lib/ndef-util.js
+++ b/ndef-lib/ndef-util.js
@@ -2,30 +2,29 @@
 // Copyright 2013 Don Coleman
 //
 
-// https://weblog.rogueamoeba.com/2017/02/27/javascript-correctly-converting-a-byte-array-to-a-utf-8-string/
+// https://gist.github.com/joni/3760795
 function _utf8ArrayToStr(data) {
-    const extraByteMap = [1, 1, 1, 1, 2, 2, 3, 0];
-    var count = data.length;
-    var str = "";
+    var str = '',
+        i;
 
-    for (var index = 0; index < count;) {
-        var ch = data[index++];
-        if (ch & 0x80) {
-            var extra = extraByteMap[(ch >> 3) & 0x07];
-            if (!(ch & 0x40) || !extra || ((index + extra) > count))
-                return null;
+    for (i = 0; i < data.length; i++) {
+        var value = data[i];
 
-            ch = ch & (0x3F >> extra);
-            for (; extra > 0; extra -= 1) {
-                var chx = data[index++];
-                if ((chx & 0xC0) != 0x80)
-                    return null;
+        if (value < 0x80) {
+            str += String.fromCharCode(value);
+        } else if (value > 0xBF && value < 0xE0) {
+            str += String.fromCharCode((value & 0x1F) << 6 | data[i + 1] & 0x3F);
+            i += 1;
+        } else if (value > 0xDF && value < 0xF0) {
+            str += String.fromCharCode((value & 0x0F) << 12 | (data[i + 1] & 0x3F) << 6 | data[i + 2] & 0x3F);
+            i += 2;
+        } else {
+            // surrogate pair
+            var charCode = ((value & 0x07) << 18 | (data[i + 1] & 0x3F) << 12 | (data[i + 2] & 0x3F) << 6 | data[i + 3] & 0x3F) - 0x010000;
 
-                ch = (ch << 6) | (chx & 0x3F);
-            }
+            str += String.fromCharCode(charCode >> 10 | 0xD800, charCode & 0x03FF | 0xDC00);
+            i += 3;
         }
-
-        str += String.fromCharCode(ch);
     }
 
     return str;

--- a/ndef-lib/ndef-wifi.js
+++ b/ndef-lib/ndef-wifi.js
@@ -1,0 +1,60 @@
+var util = require('./ndef-util');
+
+const CREDENTIAL_FIELD_ID = '100e';
+const SSID_FIELD_ID = '1045';
+const AUTH_TYPE_FIELD_ID = '1003';
+const AUTH_TYPE_OPEN = '0000';
+const AUTH_TYPE_WPA2_PSK = '0020';
+const NETWORK_KEY_FIELD_ID = '1027';
+
+// decode string bytes from ndef record payload
+// @returns an string of wifi credentials
+function decode(data) {
+  return util.bytesToString(data.slice(languageCodeLength + 1));
+  // TODO: need to parse string  into json object
+}
+
+// encode wifi object payload
+// @returns an array of bytes
+function encode(credentials) {
+  // credentials is an object containing wifi credentials such as ssid, networkKey and auth_type
+  let ssid = credentials.ssid;
+  let ssidSize = util.stringToBytes(ssid).length;
+  let authType;
+  if (credentials.authType == 'WPA') {
+    authType = AUTH_TYPE_WPA2_PSK;
+  } else {
+    authType = AUTH_TYPE_OPEN;
+  }
+  let networkKey = credentials.networkKey;
+  let networkKeySize = util.stringToBytes(networkKey).length;
+  let bufferSize = 18 + ssidSize + networkKeySize; // size of required credential attributes
+
+  let payload = [];
+  payload.push.apply(payload, hexToBytes(CREDENTIAL_FIELD_ID));
+  payload.push(0);//this zero is necessary because it serves as 'space' in credentials object when writing credentials into nfc tag
+  payload.push(bufferSize - 4);
+  payload.push.apply(payload, hexToBytes(SSID_FIELD_ID));
+  payload.push(0);
+  payload.push(ssidSize);
+  payload.push.apply(payload, util.stringToBytes(ssid));
+  payload.push.apply(payload, hexToBytes(AUTH_TYPE_FIELD_ID));
+  payload.push(0);
+  payload.push(2);
+  payload.push.apply(payload, hexToBytes(authType));
+  payload.push.apply(payload, hexToBytes(NETWORK_KEY_FIELD_ID));
+  payload.push(0);
+  payload.push(networkKeySize);
+  payload.push.apply(payload, util.stringToBytes(networkKey));
+
+  return payload;
+}
+function hexToBytes(hex) {
+  for (var bytes = [], c = 0; c < hex.length; c += 2)
+    bytes.push(parseInt(hex.substr(c, 2), 16));
+  return bytes;
+}
+module.exports = {
+  encodePayload: encode,
+  decodePayload: decode,
+};


### PR DESCRIPTION
This is a cleaned up version of the code that @deenMuhammad posted (1,2) previously.  I removed the unnecessary files and updates and successfully tested writing a WPA wifi credentials and regression tested by successfully writing a url.  Both were written on ios 13 and read using android.

1: https://github.com/whitedogg13/react-native-nfc-manager/issues/188
2: https://github.com/whitedogg13/react-native-nfc-manager/pull/200