### PR TITLE
Update AppV2Iso15693.js

### DIFF
--- a/example/AppV2Iso15693.js
+++ b/example/AppV2Iso15693.js
@@ -59,16 +59,16 @@ class AppV2Iso15693 extends React.Component {
 
       const handler = NfcManager.getIso15693HandlerIOS();
 
-      resp = await handler.getSystemInfoIOS(Nfc15693RequestFlagIOS.HighDataRate);
+      resp = await handler.getSystemInfo(Nfc15693RequestFlagIOS.HighDataRate);
       console.warn(resp);
 
-      await handler.writeSingleBlockIOS({
+      await handler.writeSingleBlock({
         flags: Nfc15693RequestFlagIOS.HighDataRate,
         blockNumber: 0,
         dataBlock: [4, 3, 2, 1]
       });
 
-      resp = await handler.readSingleBlockIOS({
+      resp = await handler.readSingleBlock({
         flags: Nfc15693RequestFlagIOS.HighDataRate,
         blockNumber: 0,
       });


### PR DESCRIPTION
As describe in issue https://github.com/whitedogg13/react-native-nfc-manager/issues/230, the interface for Iso15693 is 
interface Iso15693HandlerIOS {
    getSystemInfo: (
      requestFloags: number,
    ) => Promise<{ dsfid: number, afi: number, blockSize: number, blockCount: number, icReference: number}>;
    readSingleBlock: (params: {flags: number, blockNumber: number}) => Promise<number[]>;
    writeSingleBlock: (params: {flags: number, blockNumber: number, dataBlock: number[]}) => Promise<void>; 
    lockBlock: (params: {flags: number, blockNumber: number}) => Promise<void>; 
    writeAFI: (params: {flags: number, afi: number}) => Promise<void>; 
    lockAFI: (params: {flags: number}) => Promise<void>; 
    writeDSFID: (params: {flags: number, dsfid: number}) => Promise<void>; 
    lockDSFID: (params: {flags: number}) => Promise<void>; 
    resetToReady: (params: {flags: number}) => Promise<void>; 
    select: (params: {flags: number}) => Promise<void>; 
    stayQuite: () => Promise<void>; 
    customCommand: (params: {flags: number, customCommandCode: number, customRequestParameters: number[]}) => Promise<number[]>;
    extendedReadSingleBlock: (params: {flags: number, blockNumber: number}) => Promise<number[]>;
    extendedWriteSingleBlock: (params: {flags: number, blockNumber: number, dataBlock: number[]}) => Promise<void>; 
    extendedLockBlock: (params: {flags: number, blockNumber: number}) => Promise<void>; 
  }
It doesn't contain the 'IOS' at the end of the different methods like 'getSystemInfoIOS' which is 'getSystemInfo'