### PR TITLE
Fix jsonToReact(JSONArray jsonArray) when parsing boolean

### DIFF
--- a/android/src/main/java/community/revteltech/nfc/JsonConvert.java
+++ b/android/src/main/java/community/revteltech/nfc/JsonConvert.java
@@ -131,7 +131,7 @@ public abstract class JsonConvert {
             } else if (value instanceof JSONArray){
                 writableArray.pushArray(jsonToReact(jsonArray.getJSONArray(i)));
             } else if ("true".equals(value.toString()) || "false".equals(value.toString())){
-                writableMap.putBoolean(key, "true".equals(value.toString()));
+                writableArray.pushBoolean("true".equals(value.toString()));
             } else if (value == JSONObject.NULL){
                 writableArray.pushNull();
             }


### PR DESCRIPTION
Hi. 

Sorry, my last patch contained the wrong variable name in jsonToReact().
This will fix it.

v2.1.7 wont compile, because I'm trying to access a variable named `writableMap`, but should instead use `writableArray`.

Best regards,
Christian.