### PR TITLE
Type definition NfcManager.requestTechnology

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -117,7 +117,10 @@ declare module 'react-native-nfc-manager' {
 
     setEventListener(name: NfcEvents, callback: OnNfcEvents | null): void;
 
-    requestTechnology: (tech: NfcTech) => Promise<NfcTech>;
+    requestTechnology(
+      tech: NfcTech | NfcTech[],
+      options?: RegisterTagEventOpts
+    ): Promise<NfcTech>;
 
     cancelTechnologyRequest: () => Promise<void>;
 


### PR DESCRIPTION
A small update to requestTechnology, previous declaration only accepted a single NfcTech and no options param.
The update makes tech argument accept single value or array of NfcTech and adds options parameter as optional RegisterTagEventOpts (I believe that's the correct type).
Thanks for creating, sharing and maintaining this library!