### PR TITLE
Add readMultipleBlocks method for iso15693 on iOS

### DIFF
--- a/NfcManager.js
+++ b/NfcManager.js
@@ -62,6 +62,10 @@ class Iso15693HandlerIOS {
     return callNative('iso15693_readSingleBlock', [{flags, blockNumber}]);
   }
 
+  readMultipleBlocks({flags, blockNumber, blockCount}) {
+    return callNative('iso15693_readMultipleBlocks', [{flags, blockNumber, blockCount}]);
+  }
+
   writeSingleBlock({flags, blockNumber, dataBlock}) {
     return callNative('iso15693_writeSingleBlock', [{flags, blockNumber, dataBlock}]);
   }

--- a/index.d.ts
+++ b/index.d.ts
@@ -91,6 +91,7 @@ declare module 'react-native-nfc-manager' {
       requestFloags: number,
     ) => Promise<{ dsfid: number, afi: number, blockSize: number, blockCount: number, icReference: number}>;
     readSingleBlock: (params: {flags: number, blockNumber: number}) => Promise<number[]>;
+    readMultipleBlocks: (params: {flags: number, blockNumber: number, blockCount: number}) => Promise<number[][]>;
     writeSingleBlock: (params: {flags: number, blockNumber: number, dataBlock: number[]}) => Promise<void>; 
     lockBlock: (params: {flags: number, blockNumber: number}) => Promise<void>; 
     writeAFI: (params: {flags: number, afi: number}) => Promise<void>; 


### PR DESCRIPTION
Adds and ability to read multiple blocks at once for iso15693.

Blocks returned are not joined returning an array of array which should be fine for most cases.
Range is specified using two separate variables as common in javascript.