### PR TITLE
add readerModeDelay param

### DIFF
--- a/APIv1.md
+++ b/APIv1.md
@@ -94,7 +94,7 @@ Start to listen to *ANY* NFC tags.
 __Arguments__
 - `listener` - `function` - the callback when discovering NFC tags
 - `alertMessage` - `string` - (iOS) the message to display on iOS when the NFCScanning pops up
-- `options` - `object` - Object containing (iOS)invalidateAfterFirstRead, (Android)isReaderModeEnabled, (Android)readerModeFlags. Use `NfcAdapter` flags. **Reader mode can only be used in Android 19 or later**.
+- `options` - `object` - Object containing (iOS)invalidateAfterFirstRead, (Android)isReaderModeEnabled, (Android)readerModeFlags, (Android)readerModeDelay - set delay in seconds between one-by-one tag detection (default value 10). Use `NfcAdapter` flags. **Reader mode can only be used in Android 19 or later**.
 
 **Examples**
 
@@ -109,6 +109,7 @@ NfcManager.registerTagEvent(
     isReaderModeEnabled: true,
     readerModeFlags:
       NfcAdapter.FLAG_READER_NFC_A | NfcAdapter.FLAG_READER_SKIP_NDEF_CHECK,
+      readerModeDelay: 2,
   },
 );
 ```

--- a/NfcManager.js
+++ b/NfcManager.js
@@ -12,6 +12,7 @@ const DEFAULT_REGISTER_TAG_EVENT_OPTIONS = {
   invalidateAfterFirstRead: false,
   isReaderModeEnabled: false,
   readerModeFlags: 0,
+  readerModeDelay: 10,
 };
 
 const NfcEvents = {

--- a/android/src/main/java/community/revteltech/nfc/NfcManager.java
+++ b/android/src/main/java/community/revteltech/nfc/NfcManager.java
@@ -52,6 +52,7 @@ class NfcManager extends ReactContextBaseJavaModule implements ActivityEventList
     // Use NFC reader mode instead of listening to a dispatch
     private Boolean isReaderModeEnabled = false;
     private int readerModeFlags = 0;
+    private int readerModeDelay = 0;
 
     class WriteNdefRequest {
         NdefMessage message;
@@ -888,6 +889,7 @@ class NfcManager extends ReactContextBaseJavaModule implements ActivityEventList
     private void registerTagEvent(ReadableMap options, Callback callback) {
         this.isReaderModeEnabled = options.getBoolean("isReaderModeEnabled");
         this.readerModeFlags = options.getInt("readerModeFlags");
+        this.readerModeDelay = options.getInt("readerModeDelay");
 
         Log.d(LOG_TAG, "registerTag");
         isForegroundEnabled = true;
@@ -967,7 +969,7 @@ class NfcManager extends ReactContextBaseJavaModule implements ActivityEventList
                     if (enable) {
                         Log.i(LOG_TAG, "enableReaderMode");
                         Bundle readerModeExtras = new Bundle();
-                        readerModeExtras.putInt(NfcAdapter.EXTRA_READER_PRESENCE_CHECK_DELAY, 10000);
+                        readerModeExtras.putInt(NfcAdapter.EXTRA_READER_PRESENCE_CHECK_DELAY, readerModeDelay * 1000);
                         nfcAdapter.enableReaderMode(currentActivity, new NfcAdapter.ReaderCallback() {
                             @Override
                             public void onTagDiscovered(Tag tag) {

--- a/index.d.ts
+++ b/index.d.ts
@@ -69,6 +69,7 @@ declare module 'react-native-nfc-manager' {
     invalidateAfterFirstRead?: boolean;
     isReaderModeEnabled?: boolean;
     readerModeFlags?: number;
+    readerModeDelay?: number;
   }
 
   interface NdefWriteOpts {


### PR DESCRIPTION
Hello!

I was noticed that after detection one tag should pass about 10 seconds to detect another (because of NfcAdapter.EXTRA_READER_PRESENCE_CHECK_DELAY). It could be not very convenient when you read one-to-one tags. I decided to add new parameter `readerModeDelay` which set delay between tag detection. Default value of parameter is 10 seconds (to save backward compatibility). 
