### PR TITLE
[config plugin] Added support for selectIdentifiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ Next, rebuild your app as described in the ["Adding custom native code"](https:/
 The plugin provides props for extra customization. Every time you change the props or plugins, you'll need to rebuild (and `prebuild`) the native app. If no extra properties are added, defaults will be used.
 
 - `nfcPermission` (_string | false_): Sets the iOS `NFCReaderUsageDescription` permission message to the `Info.plist`. Setting `false` will skip adding the permission. Defaults to `Allow $(PRODUCT_NAME) to interact with nearby NFC devices`.
+- `selectIdentifiers` (_string[]_): Sets the iOS [`com.apple.developer.nfc.readersession.iso7816.select-identifiers`](https://developer.apple.com/documentation/bundleresources/information_property_list/select-identifiers) entitlements to a list of supported application IDs.
 
 #### Example
 
@@ -193,7 +194,8 @@ The plugin provides props for extra customization. Every time you change the pro
       [
         "react-native-nfc-manager",
         {
-          "nfcPermission": "Custom permission message"
+          "nfcPermission": "Custom permission message",
+          "selectIdentifiers": ["A0000002471001"]
         }
       ]
     ]


### PR DESCRIPTION
Follow up to https://github.com/whitedogg13/react-native-nfc-manager/pull/399#issuecomment-849588150

Added support for a `selectIdentifiers` prop in the config plugin. This will populate the `com.apple.developer.nfc.readersession.iso7816.select-identifiers` entitlement on iOS.