### PR TITLE
remove build tools version

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -15,8 +15,6 @@ apply plugin: 'com.android.library'
 
 android {
 	compileSdkVersion safeExtGet('compileSdkVersion', 27)
-	buildToolsVersion safeExtGet('buildToolsVersion', '27.0.3')
-
 	defaultConfig {
 		minSdkVersion safeExtGet('minSdkVersion', 16)
     	//noinspection OldTargetApi


### PR DESCRIPTION
Setting buildToolsVersion is no longer recommended, it'll default to Android Gradle Plugin defaults. It makes DX worse by requiring multiple versions of build tools by various dependencies require various versions.
